### PR TITLE
Change from xlsx to writexl

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,5 +31,5 @@ Depends:
     sf,
     tidytext,
     vctrs,
-    xlsx,
+    writexl,
     R (>= 4.3.1)

--- a/R/function_export_AHgen.R
+++ b/R/function_export_AHgen.R
@@ -89,7 +89,7 @@ export_AHgen <- function(output,
     
     filenameXLSX <- filenameTimestamp(prefix = prefixXLSX, extension = ".xlsx")
     
-    outputXLSX %>% xlsx::write.xlsx(filenameXLSX)
+    outputXLSX %>% writexl::write_xlsx(filenameXLSX)
     message(paste0("Files saved as: "))
     message(paste0("\n\t", filenameXLSX))
     

--- a/vignettes/Vignette 7A - Application - Generate template Urban Systems Abstraction Hierarchy.Rmd
+++ b/vignettes/Vignette 7A - Application - Generate template Urban Systems Abstraction Hierarchy.Rmd
@@ -181,7 +181,7 @@ USAH_template_baseline %>%
 
 # If subnetwork assignment has been updated, write out to .xlsx for future use
 USAH_template_baseline$vInfo %>% 
- write.xlsx(
+ writexl::write_xlsx(
    filenameTimestamp(
      prefix = paste0(directory,
                      name, "_", version, "_", location, "_", scenario, 

--- a/vignettes/Vignette-7A---Application---Generate-template-Urban-Systems-Abstraction-Hierarchy.html
+++ b/vignettes/Vignette-7A---Application---Generate-template-Urban-Systems-Abstraction-Hierarchy.html
@@ -1895,7 +1895,7 @@ AHgen</a>.</p>
 <span id="cb33-9"><a href="#cb33-9" tabindex="-1"></a></span>
 <span id="cb33-10"><a href="#cb33-10" tabindex="-1"></a><span class="co"># If subnetwork assignment has been updated, write out to .xlsx for future use</span></span>
 <span id="cb33-11"><a href="#cb33-11" tabindex="-1"></a>USAH_template_baseline<span class="sc">$</span>vInfo <span class="sc">%&gt;%</span> </span>
-<span id="cb33-12"><a href="#cb33-12" tabindex="-1"></a> <span class="fu">write.xlsx</span>(</span>
+<span id="cb33-12"><a href="#cb33-12" tabindex="-1"></a> <span class="fu">writexl::write_xlsx</span>(</span>
 <span id="cb33-13"><a href="#cb33-13" tabindex="-1"></a>   <span class="fu">filenameTimestamp</span>(</span>
 <span id="cb33-14"><a href="#cb33-14" tabindex="-1"></a>     <span class="at">prefix =</span> <span class="fu">paste0</span>(directory,</span>
 <span id="cb33-15"><a href="#cb33-15" tabindex="-1"></a>                     name, <span class="st">&quot;_&quot;</span>, version, <span class="st">&quot;_&quot;</span>, location, <span class="st">&quot;_&quot;</span>, scenario, </span>


### PR DESCRIPTION
Hi - 

I have changed the dependency from xlsx to writexl. 

xlsx depends on java and I understand that Oracle have changed the license terms for Java so it is very expensive for large organisations.  Writexl (and there are others) don't depend on java. 

My company has removed java from our computers because of the cost and so I couldn't run the original package.  